### PR TITLE
Add EDGEMICRO_CONFIG_DIR environment variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG ENV=someenv
 #ENV EDGEMICRO_ENV=$ENV
 #ENV EDGEMICRO_KEY=$KEY
 #ENV EDGEMICRO_SECRET=$SECRET
+#ENV ENV EDGEMICRO_CONFIG_DIR=/home/microgateway/.edgemicro
 
 RUN groupadd microgateway
 RUN useradd microgateway -g microgateway -m -d /home/microgateway


### PR DESCRIPTION
`EDGEMICRO_CONFIG_DIR` was missing in the Dockerfile, which lead to Config not found error when ran outside of k8s. Hence, added the variable to the Dockerfile.